### PR TITLE
Remove redundant directory creation in Ubuntu workflow

### DIFF
--- a/.github/workflows/UbuntuProcesses.yml
+++ b/.github/workflows/UbuntuProcesses.yml
@@ -11,7 +11,6 @@ jobs:
       - name: Generate site/processes-ubuntu.html
         shell: pwsh
         run: |
-          mkdir -p site | Out-Null
           $tz    = [TimeZoneInfo]::FindSystemTimeZoneById('America/Chicago')
           $nowCT = [TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow,$tz)
           $abbr  = $tz.IsDaylightSavingTime($nowCT) ? 'CDT' : 'CST'


### PR DESCRIPTION
## Summary
- remove unnecessary `mkdir -p site` step from UbuntuProcesses workflow

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689fe8ba563483329316eff661b423d8