### PR TITLE
Add script-based Ubuntu workflow

### DIFF
--- a/.github/workflows/UbuntuProcesses.yml
+++ b/.github/workflows/UbuntuProcesses.yml
@@ -11,7 +11,6 @@ jobs:
       - name: Generate site/processes-ubuntu.html
         shell: pwsh
         run: |
-          mkdir -p site | Out-Null
           $tz    = [TimeZoneInfo]::FindSystemTimeZoneById('America/Chicago')
           $nowCT = [TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow,$tz)
           $abbr  = $tz.IsDaylightSavingTime($nowCT) ? 'CDT' : 'CST'

--- a/.github/workflows/ubuntuprocesses2.yaml
+++ b/.github/workflows/ubuntuprocesses2.yaml
@@ -1,0 +1,35 @@
+name: Publish processes (Ubuntu) to Pages (script)
+on: workflow_dispatch
+permissions: { pages: write, id-token: write, contents: write }
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate site/ubuntuprocesses2.html
+        shell: pwsh
+        run: ./PowerShell/ubuntuprocesses.ps1
+
+      - name: Commit file to master
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add site/ubuntuprocesses2.html
+          git commit -m "Update site/ubuntuprocesses2.html (Ubuntu)" || echo "No changes"
+          git push
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/PowerShell/ubuntuprocesses.ps1
+++ b/PowerShell/ubuntuprocesses.ps1
@@ -1,0 +1,8 @@
+$tz    = [TimeZoneInfo]::FindSystemTimeZoneById('America/Chicago')
+$nowCT = [TimeZoneInfo]::ConvertTimeFromUtc([DateTime]::UtcNow,$tz)
+$abbr  = $tz.IsDaylightSavingTime($nowCT) ? 'CDT' : 'CST'
+$stamp = $nowCT.ToString('MMddyy:HHmmss') + " $abbr"
+
+Get-Process | Sort-Object WorkingSet64 -Descending | Select-Object -First 20 ProcessName, Id, CPU, WS |
+  ConvertTo-Html -As Table -Title 'Processes' -PreContent "<h1>Processes (Ubuntu runner)</h1><p>Updated $stamp</p>" |
+  Set-Content site/ubuntuprocesses2.html -Encoding utf8


### PR DESCRIPTION
## Summary
- add PowerShell script to generate Ubuntu process report
- add workflow that runs script and publishes `ubuntuprocesses2.html`

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689fe8ba563483329316eff661b423d8