### PR TITLE
Fix devcontainer to install Git

### DIFF
--- a/.devcontainer/DockerFile
+++ b/.devcontainer/DockerFile
@@ -1,4 +1,0 @@
-# FROM mcr.microsoft.com/azure-powershell:latest
-# USER root
-# install git
-RUN apt install -y git

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/azure-powershell:latest
+
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,19 @@
 {
     "name": "AzPSImage",
-    //  "dockerFile": "Dockerfile",
-    "image": "mcr.microsoft.com/azure-powershell:latest",
+    "dockerFile": "Dockerfile",
     "customizations": {
         "vscode": {
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "pwsh",
-                
+
                 "workbench.sideBar.location": "right",
                 "editor.multiCursorModifier": "ctrlCmd", "editor.minimap.enabled": false, "editor.accessibilitySupport": "on", "editor.tabCompletion": "on",
                 "editor.snippetSuggestions": "bottom", "editor.suggest.snippetsPreventQuickSuggestions": true, "editor.rulers": [125],
                 "editor.bracketPairColorization.enabled": true, "editor.guides.bracketPairs": "active"
 
             },
-            
-            "postCreateCommand": "sudo apt-get update && sudo apt-get install -y git",
 
-            "extensions": 
+            "extensions":
             ["ms-vscode.powershell",
              "ibm.output-colorizer",
              "github.copilot", "github.copilot-chat",


### PR DESCRIPTION
## Summary
- build devcontainer from Azure PowerShell base image
- install Git during image build
- reference Dockerfile directly in devcontainer.json

## Testing
- `npm test` (fails: could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3ba4fc4248332b79f43eb423b3bcd